### PR TITLE
use less OOP

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,6 @@ a minifier for html written in python
 ```python
 from html_minifier.minify import Minifier
 
-minifier = Minifier(html)
-html = minifier.minify()
-```
-
-for a reuse is better 
-
-```python
-from html_minifier.minify import Minifier
-
 minifier = Minifier()
-
-for i in range(100):
-    minifier.html = html
-    html = minifier.minify()
-
+html = minifier.minify(html)
 ```

--- a/html_minifier/minify.py
+++ b/html_minifier/minify.py
@@ -9,8 +9,7 @@ class Minifier(object):
     _array = ("}{", "><", "}<", ">{")
     _array_regex = (r"}\s{", r">\s<", r"}\s<", r">\s{")
 
-    def __init__(self, html=""):
-        self.html = html
+    def __init__(self):
         self.convert_to_space = re.compile(self._re_for_Whitespace)
         self.remove_commets = re.compile(self._re_for_commets)
         self.remove_spaces_in_tags = self.list_regex_spaces_tags()
@@ -39,8 +38,7 @@ class Minifier(object):
     def removeComments(self, html):
         return self.remove_commets.sub("", html)
 
-    def minify(self):
-        html = self.html
+    def minify(self, html):
         html = self.stripWhitespace(html)
         html = self.collapseWhitespace(html)
         html = self.removeComments(html)
@@ -51,8 +49,8 @@ class Minifier(object):
 
 class DjangoMinifier(Minifier):
 
-    def __init__(self, html=""):
+    def __init__(self):
         self._array += ("{{", "}}", "{%", "%}")
         self._array_regex += (r"(\s+)?{{(\s+)?", r"(\s+)?}}(\s+)?",
                               r"(\s+)?{%(\s+)?", r"(\s+)?%}(\s+)?")
-        super(DjangoMinifier, self).__init__(html)
+        super(DjangoMinifier, self).__init__()

--- a/test/test.py
+++ b/test/test.py
@@ -25,8 +25,8 @@ class TestMinify(unittest.TestCase):
             f.close()
 
     def test_minifier(self):
-        mini = Minifier(self.html)
-        self.assertEqual(mini.minify(), self.html_min)
+        mini = Minifier()
+        self.assertEqual(mini.minify(self.html), self.html_min)
 
 
 class TestMinifyDjango(TestMinify):
@@ -34,5 +34,5 @@ class TestMinifyDjango(TestMinify):
     file_name = "django"
 
     def test_minifier(self):
-        mini = DjangoMinifier(self.html)
-        self.assertEqual(mini.minify(), self.html_min)
+        mini = DjangoMinifier()
+        self.assertEqual(mini.minify(self.html), self.html_min)


### PR DESCRIPTION
The value of Minifier class is to encapsulate regexp patterns and allow inheritance for Django minifier.
It has no value in encapsulating the HTML content.
So I moved it out.